### PR TITLE
Implement "tiny" size, change title text, and fix vertical spacing in tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or a color code and a name
 
     <colorswatch #FFFF00:some_yellow>
     
-The plugin only supports hexadecimal color codes (the ones starting with ``#``), no functions like ``rgb()`` or ``hsla()`` or keywords like ``lightgray`` or ``fuchsia``. In the plugin's settings, it's possible to choose between small, middle sized and large color swatches. That setting is global, changes get applied the next time the wiki page with the color swatches in them is saved.
+The plugin only supports hexadecimal color codes (the ones starting with ``#``), no functions like ``rgb()`` or ``hsla()`` or keywords like ``lightgray`` or ``fuchsia``. In the plugin's settings, it's possible to choose between tiny, small, medium-sized, and large color swatches.  The size setting is global and changes get applied the next time the wiki page with the color swatches in them is saved.
 
 All documentation for this plugin can be found at
 https://github.com/hkockerbeck/dokuwiki_colorswatch

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,5 +6,5 @@
  */
 
 
-$meta['colorswatch_size'] = array('multichoice', '_choices' => array('colorswatch_small', 'colorswatch_middle', 'colorswatch_large'));
+$meta['colorswatch_size'] = array('multichoice', '_choices' => array('colorswatch_tiny', 'colorswatch_small', 'colorswatch_middle', 'colorswatch_large'));
 

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * english language file for colorswatch plugin
+ * german language file for colorswatch plugin
  *
  * @author Henning Kockerbeck <henning.kockerbeck@isatis-online.de>
  */
@@ -8,6 +8,7 @@
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
 $lang['colorswatch_size'] = 'Größe des Farbtonmusters (global; Änderungen werden beim nächsten Speichern der jeweiligen Wiki-Seite wirksam)';
+$lang['colorswatch_size_o_colorswatch_tiny'] = 'Winzig';
 $lang['colorswatch_size_o_colorswatch_small'] = 'Klein';
 $lang['colorswatch_size_o_colorswatch_middle'] = 'Mittel';
 $lang['colorswatch_size_o_colorswatch_large'] = 'Groß';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,6 +8,7 @@
 // keys need to match the config setting name
 // $lang['fixme'] = 'FIXME';
 $lang['colorswatch_size'] = 'Size of the colorswatch (global; gets adjusted at the next save of the page)';
+$lang['colorswatch_size_o_colorswatch_tiny'] = 'Tiny';
 $lang['colorswatch_size_o_colorswatch_small'] = 'Small';
 $lang['colorswatch_size_o_colorswatch_middle'] = 'Middle';
 $lang['colorswatch_size_o_colorswatch_large'] = 'Large';

--- a/style.css
+++ b/style.css
@@ -4,6 +4,11 @@
   margin: 0.3rem;
 }
 
+.colorswatch.colorswatch_tiny {
+  height: 1rem;
+  width: 2rem;
+}
+
 .colorswatch.colorswatch_small {
   height: 4rem;
   width: 6rem;

--- a/style.css
+++ b/style.css
@@ -5,23 +5,23 @@
 }
 
 .colorswatch.colorswatch_tiny {
-  height: 1rem;
-  width: 2rem;
+  min-height: 1rem;
+  min-width: 2rem;
 }
 
 .colorswatch.colorswatch_small {
-  height: 4rem;
-  width: 6rem;
+  min-height: 4rem;
+  min-width: 6rem;
 }
 
 .colorswatch.colorswatch_middle {
-  height: 6rem;
-  width: 8rem;
+  min-height: 6rem;
+  min-width: 8rem;
 }
 
 .colorswatch.colorswatch_large {
-  height: 8rem;
-  width: 10rem;
+  min-height: 8rem;
+  min-width: 10rem;
 }
 
 .colorswatch .colorswatch_swatch {
@@ -35,5 +35,5 @@
   height: 34%;
   font-size: 85%;
   text-align: center;
-  padding: 0.3rem 0;
+  padding: 0.3rem 0 0;
 }

--- a/syntax/colorswatch.php
+++ b/syntax/colorswatch.php
@@ -106,15 +106,14 @@ class syntax_plugin_colorswatch_colorswatch extends DokuWiki_Syntax_Plugin
 
 	if ($data['name'] != '') 
 	{
-	    $name = hsc($data['name']) . '<br>(' . hsc($code) . ')';
+	    $name = hsc($data['name']);
 	}
 	else
 	{
-	    $name = hsc($code) . '<br>&nbsp;';
+	    $name = $code; // It's already escaped above.
 	}
 
 	$size_class = $this->getConf('colorswatch_size');
-
 
 	$renderer->doc .= <<<EOT
 <div class="colorswatch $size_class"><div class="colorswatch_swatch" style="background-color: $code;">&nbsp;</div><div class="colorswatch_info">$name</div></div>


### PR DESCRIPTION
1. Add "tiny" size (1rem), especially for use with tables
2. Don't show the hex color code when a name is provided (it's distracting)
3. In tables, the name/color-code was sticking out of the cell, so change the size of the outer div to expand to cover it